### PR TITLE
Better support for third party packages or frameworks on deferhttp

### DIFF
--- a/deferstats/http.go
+++ b/deferstats/http.go
@@ -44,7 +44,7 @@ func HTTPHandler(f func(w http.ResponseWriter, r *http.Request)) func(w http.Res
 	}
 }
 
-func AddRequest(start_time int, path string) {
+func AddRequest(start_time time.Time, path string) {
 	
 	// It's just an easier way to create third-party middlewares
 	appendHTTP(start_time, path)

--- a/deferstats/http.go
+++ b/deferstats/http.go
@@ -2,6 +2,7 @@ package deferstats
 
 import (
 	"github.com/deferpanic/deferclient/deferclient"
+	"log"
 	"net/http"
 	"time"
 )
@@ -45,7 +46,11 @@ func HTTPHandler(f func(w http.ResponseWriter, r *http.Request)) func(w http.Res
 }
 
 func AddRequest(start_time time.Time, path string) {
-	
+
+	if Verbose {
+		log.Printf("Added manual request: %v\n", path)
+	}
+
 	// It's just an easier way to create third-party middlewares
 	appendHTTP(start_time, path)
 }

--- a/deferstats/http.go
+++ b/deferstats/http.go
@@ -43,3 +43,9 @@ func HTTPHandler(f func(w http.ResponseWriter, r *http.Request)) func(w http.Res
 		appendHTTP(startTime, r.URL.Path)
 	}
 }
+
+func AddRequest(start_time int, path string) {
+	
+	// It's just an easier way to create third-party middlewares
+	appendHTTP(start_time, path)
+}

--- a/deferstats/stats.go
+++ b/deferstats/stats.go
@@ -12,8 +12,8 @@ import (
 
 // fixme
 const (
-	// statsFrequency controls how often to report into deferpanic
-	statsFrequency = 60 * time.Second
+	// statsFrequency controls how often to report into deferpanic in seconds
+	statsFrequency = 60
 
 	// statsUrl is the stats api endpoint
 	statsUrl = deferclient.ApiBase + "/stats/create"
@@ -55,10 +55,12 @@ type DeferStats struct {
 
 // CaptureStats POSTs DeferStats every
 func CaptureStats() {
-	for {
+	
+	tickerChannel := time.Tick(time.Duration(statsFrequency) * time.Second)
+	for ts := range tickerChannel {
+		
+		// Capture the stats every X seconds
 		go capture()
-		// set me to a reasonable timeout
-		time.Sleep(statsFrequency)
 	}
 }
 

--- a/deferstats/stats.go
+++ b/deferstats/stats.go
@@ -30,6 +30,7 @@ const (
 
 // Token is your deferpanic token available in settings
 var Token string
+var Verbose bool = false
 
 // DeferHTTP holds the path uri and latency for each request
 type DeferHTTP struct {
@@ -61,6 +62,10 @@ func CaptureStats() {
 		
 		// Capture the stats every X seconds
 		go capture()
+		
+		if Verbose {
+			log.Printf("Captured at:%v\n", ts)
+		}
 	}
 }
 


### PR DESCRIPTION
I didnt find a creative way to use the library to collect my gingonic http stats without needing to make some changes to the library. Now you can **use deferpanic with gin gonic** or any other framework.

You can add a middleware that adds the http requests manually like this:

```go
// Start gin with classic middlewares
g := gin.Default()

// Add the deferpanic recovery for gingonic
g.Use(func(c *gin.Context) {

	startTime := time.Now()

	c.Next()

        // Add the request to the list of played urls
	deferstats.AddRequest(startTime, c.Request.URL.Path)
})
```

And then your http requests will be collected by deferpanic