### PR TITLE
Address multiple issues

### DIFF
--- a/deferclient/client.go
+++ b/deferclient/client.go
@@ -8,6 +8,7 @@ import (
 	"log"
 	"net/http"
 	"runtime"
+	"runtime/debug"
 	"strings"
 )
 
@@ -31,6 +32,10 @@ var Token string
 // Bool that turns off tracking of errors and panics - useful for
 // dev/test environments
 var NoPost = false
+
+// PrintPanics controls whether or not the HTTPHandler function prints
+// recovered panics. It is disabled by default.
+var PrintPanics = false
 
 // struct that holds expected json body for POSTing to deferpanic API v1
 type DeferJSON struct {
@@ -65,6 +70,11 @@ func Prep(err interface{}) {
 	errorMsg := fmt.Sprintf("%q", err)
 
 	errorMsg = strings.Replace(errorMsg, "\"", "", -1)
+
+	if PrintPanics {
+		stack := string(debug.Stack())
+		fmt.Println(stack)
+	}
 
 	body := ""
 	for skip := 1; ; skip++ {

--- a/deferstats/db.go
+++ b/deferstats/db.go
@@ -22,8 +22,8 @@ func (d *deferDBList) Add(item DeferDB) {
 
 // List returns a copy of the list
 func (d *deferDBList) List() []DeferDB {
-	list := make([]DeferDB, len(d.list))
 	d.lock.RLock()
+	list := make([]DeferDB, len(d.list))
 	for i, v := range d.list {
 		list[i] = v
 	}

--- a/deferstats/http.go
+++ b/deferstats/http.go
@@ -49,6 +49,8 @@ var curlist = &deferHTTPList{}
 
 var latencyThreshold = 200
 
+// WritePanicResponse is an overridable function that, by default, writes the contents of the panic
+// error message with a 500 Internal Server Error.
 var WritePanicResponse = func(w http.ResponseWriter, r *http.Request, errMsg string) {
 	w.WriteHeader(http.StatusInternalServerError)
 	w.Write([]byte(errMsg))

--- a/deferstats/http.go
+++ b/deferstats/http.go
@@ -1,6 +1,7 @@
 package deferstats
 
 import (
+	"fmt"
 	"log"
 	"math/rand"
 	"net/http"
@@ -47,6 +48,11 @@ func (d *deferHTTPList) Reset() {
 var curlist = &deferHTTPList{}
 
 var latencyThreshold = 200
+
+var WritePanicResponse = func(w http.ResponseWriter, r *http.Request, errMsg string) {
+	w.WriteHeader(http.StatusInternalServerError)
+	w.Write([]byte(errMsg))
+}
 
 // appendHTTP adds a new http request to the list
 func appendHTTP(startTime time.Time, path string, status_code int, span_id int64, parent_span_id int64) {
@@ -147,6 +153,9 @@ func HTTPHandler(f func(w http.ResponseWriter, r *http.Request)) func(w http.Res
 				deferclient.Prep(err)
 				// FIXME
 				appendHTTP(startTime, r.URL.Path, 500, 0, 0)
+
+				errorMsg := fmt.Sprintf("%v", err)
+				WritePanicResponse(w, r, errorMsg)
 			}
 		}()
 

--- a/deferstats/http.go
+++ b/deferstats/http.go
@@ -27,8 +27,8 @@ func (d *deferHTTPList) Add(item DeferHTTP) {
 
 // List returns a copy of the list
 func (d *deferHTTPList) List() []DeferHTTP {
-	list := make([]DeferHTTP, len(d.list))
 	d.lock.RLock()
+	list := make([]DeferHTTP, len(d.list))
 	for i, v := range d.list {
 		list[i] = v
 	}


### PR DESCRIPTION
Fixes an issue where shared memory is being accessed outside mutex.
Fixes an issue where panics were being swallowed by `deferstats.HTTPHandler` and not being printed when test were run.
Fixes an issue where a panic was returning `200 OK` instead of `500 Internal Server Error`.

Fixes #15
Fixes #16
Fixes #17